### PR TITLE
images and videos now handled by single page; also supports YT videos

### DIFF
--- a/site/fullscreen/index.html
+++ b/site/fullscreen/index.html
@@ -1,0 +1,172 @@
+<html>
+    <head>
+        <style type="text/css">
+            html { 
+                background: black no-repeat center center fixed; 
+            }
+
+            html, body {
+                min-width: 100%;
+                min-height: 100%;
+                height: 100%;
+                width: 100%;
+                padding: 0;
+                margin: 0;
+            }
+
+            #media {
+                position: fixed;
+                object-fit: contain;
+                height: 100%;
+                width: 100%;
+                z-index: -100;
+            }
+        </style>
+        <script type="text/javascript">
+            // valid file extensions
+            image_file_exts = [
+                "jpg",
+                "jpeg",
+                "jpe",
+                "jif",
+                "jfif",
+                "jfi",
+                "png",
+                "apng",
+                "bmp",
+                "dib",
+                "gif",
+            ];
+            video_file_exts = [
+                "gifv",
+                "webm",
+                "mp4",
+            ];
+
+            // notable domains to check for
+            imgur_domains = [
+                "i.imgur.com",
+                "www.imgur.com",
+                "imgur.com",
+            ];
+            youtube_domains = [
+                "www.youtube.com",
+                "www.youtu.be",
+                "youtube.com",
+                "youtu.be"
+            ];
+
+            function extractDomain(url) {
+                var domain;
+                //find & remove protocol (http, ftp, etc.) and get domain
+                if (url.indexOf("://") > -1) {
+                    domain = url.split('/')[2];
+                }
+                else {
+                    domain = url.split('/')[0];
+                }
+                //find & remove port number
+                domain = domain.split(':')[0];
+
+                return domain;
+            }
+
+            function spawnYouTubePlayer(url) {
+                video_id = extractYouTubeVideoID(url);
+            }
+
+            function extractYouTubeVideoID(url) {
+                var video_id;
+                var regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
+                var match = url.match(regExp);
+                console.log(match);
+                console.log(match[2]);
+                if (match && match[2].length == 11) {
+                    return match[2];
+                } else {
+                    //error
+                }
+            }
+
+            function extractFileExtension(url) {
+                var extension;
+                var regExp = /.*\.([a-zA-Z]+)$/;
+                var match = url.match(regExp);
+                console.log(match);
+                console.log(match[1]);
+                if (match) {
+                    return match[1];
+                } else {
+                    //error
+                }
+            }
+
+            function spawnImgElement(url) {
+                var body = document.getElementsByTagName("body")[0]
+                var img = document.createElement("IMG");
+                img.setAttribute("id", "media");
+                img.setAttribute("src", url);
+                body.appendChild(img);
+                return;
+            }
+
+            function spawnVideoElement(url) {
+                var body = document.getElementsByTagName("body")[0]
+                var video = document.createElement("VIDEO");
+                video.setAttribute("id", "media");
+                video.setAttribute("loop", "loop");
+                video.setAttribute("preload", "auto");
+                video.setAttribute("autoplay", "autoplay");
+                video.setAttribute("src", url);
+                body.appendChild(video);
+                return;
+            }
+
+            function spawnYouTubePlayer(url) {
+                var body = document.getElementsByTagName("body")[0]
+                video_id = extractYouTubeVideoID(url);
+                var iframe = document.createElement("IFRAME");
+                iframe.setAttribute("id", "media");
+                iframe.setAttribute("height", "100%");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("src", "http://www.youtube.com/embed/" + video_id + "?playlist=" + video_id +"&autoplay=1&controls=0&autohide=1&loop=1&showinfo=0");
+                body.appendChild(iframe);
+            }
+
+            window.onload=function(){
+                // grab the media's URL
+                var query = window.location.search;
+                if (query == null){
+                    return;
+                }
+                url = query.substr(1);
+                // figure out who is hosting the media
+                var domain = extractDomain(url);
+                if (youtube_domains.indexOf(domain) > -1) {
+                    // if it's a YT video, a player will need to be embeded
+                    spawnYouTubePlayer(url);
+                }
+                else {
+                    // no embeded player is needed
+                    if (imgur_domains.indexOf(domain) > -1) {
+                        // if hosted on imgur, enforce .webm if applicable
+                        url = url.replace(/\.gif(v)?/g, ".webm")
+                    }
+                    // grab the file ext to determine how to display the media
+                    file_ext = extractFileExtension(url);
+                    if (image_file_exts.indexOf(file_ext) > -1) {
+                        // url links to image file
+                        spawnImgElement(url);
+                    }
+                    else if (video_file_exts.indexOf(file_ext) > -1) {
+                        // url links to video file
+                        spawnVideoElement(url);
+                    }
+                    return;
+                }
+            }
+        </script>
+    </head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
Created a new directory, 'fullscreen', to replace the 'fullscreen-image' and 'fullscreen-video' directories. The new page handles both images and videos, as well as the embedding of YouTube videos (regardless of URL format). It also recognizes imgur URLs in the event that a .gif or .gifv is passed, so it can force it to use .webm instead. 
